### PR TITLE
fix filename casing for www script

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
         A Cordova plugin to get the system uptime for Android and iOS platforms.
     </description>
     <license>MIT</license>
-    <js-module name="Uptime" src="www/uptime.js">
+    <js-module name="Uptime" src="www/Uptime.js">
         <clobbers target="Uptime"/>
     </js-module>
     <platform name="android">


### PR DESCRIPTION
Fixes this error when using cordova CLI v12.x with node v16.x

```
Discovered plugin "cordova-plugin-uptime". Adding it to the project
Installing "cordova-plugin-uptime" for android
Error during processing of action! Attempting to revert...
Failed to install 'cordova-plugin-uptime': Error: Uh oh!
ENOENT: no such file or directory, open '[...]/plugins/cordova-plugin-uptime/www/uptime.js'
    at Object.openSync (node:fs:590:3)
    at Object.readFileSync (node:fs:458:35)
    at install ([...]/node_modules/cordova-android/lib/pluginHandlers.js:162:36)
    at ActionStack.process ([...]/node_modules/cordova-common/src/ActionStack.js:55:25)
    at PluginManager.doOperation ([...]/node_modules/cordova-common/src/PluginManager.js:111:24)
    at PluginManager.addPlugin ([...]/node_modules/cordova-common/src/PluginManager.js:141:21)
    at [...]/node_modules/cordova-android/lib/Api.js:155:78
Failed to restore plugin "cordova-plugin-uptime". You might need to try adding it again. Error: Error: Uh oh!
ENOENT: no such file or directory, open '[...]/plugins/cordova-plugin-uptime/www/uptime.js'
```